### PR TITLE
chore: correct outdated Databricks terminology in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ As a skilled data engineer, you have already collected a dataset containing hous
 
 ### Goal of the Assessment
 
-The aim is to identify postal codes with investment potential and determine whether renting properties long-term through Kamernet or via Airbnb would be more profitable.
+The aim is to identify postcodes with investment potential and determine whether renting properties long-term through Kamernet or via Airbnb would be more profitable.
 
 ## Product Development
 
@@ -43,9 +43,9 @@ The following deliverables are expected as part of the project:
 - Export of datasets produced by your pipeline, formatted as Parquet files (placed in `./data/output`)
 - Pipeline job configurations (included in the `./resources` folder)
 
-We highly recommend using Databricks, you can set up a [free trial for professional use following Express Setup](http://signup.databricks.com/). Note that Community Edition does not provide all the functionality required for this assignment. However, we are primarily interested in understanding how you work, so feel free to pick a tool with which you are most comfortable—whether it’s a local PySpark instance, or a cloud service. Explain your reasoning.
+We highly recommend using Databricks, you can set up a [free trial for professional use following Express Setup](https://signup.databricks.com/) or [Databricks Free Edition](https://www.databricks.com/learn/free-edition). However, we are primarily interested in understanding how you work, so feel free to pick a tool with which you are most comfortable—whether it’s a local PySpark instance, or a cloud service. Explain your reasoning.
 
-Save everything in a private Git repository and share it with us. Deliver a clean repository: remove any redundant files, replace our README with your own, and provide clear instructions for building and running your project. If unsure how to structure your repository, we recommend starting with our [RevoData Asset Bundle Templates](https://github.com/revodatanl/revo-asset-bundle-templates). We expect you to spend 3-4 hours on the assessment, so apply your best judgment when prioritizing tasks.
+Save everything in a private Git repository and share it with us. Deliver a clean repository: remove any redundant files, replace our README with your own, and provide clear instructions for building and running your project. If unsure how to structure your repository, we recommend starting with our [RevoData Declarative Automation Bundle Templates](https://github.com/revodatanl/revo-dabs). We expect you to spend 3-4 hours on the assessment, so apply your best judgment when prioritizing tasks.
 
 ### Stretch Goals
 
@@ -62,17 +62,13 @@ Following are a number of stretch goals of increasing difficulty that will give 
 - [ ] Build a visualization or dashboard displaying potential revenue per postcode (rental and Airbnb)
 - [ ] Create diagrams of the data flows and of your CI/CD pipeline
 
-> **Please note:** for the following sections, you **will** need Databricks. Delta Live Tables (DLT) is not available in Databricks Community Edition, so you should use the free trial if you got this far. However, be aware that the free trial comes with capacity limitations that may impact your ability to complete the goals.
->
-> _Continue at your own risk._
-
 ### BONUS
 
 #### Level 3 / Future-Proof
 
-- [ ] Use Delta Live Tables (DLT) to build your pipelines
-- [ ] Use expectations (if using DLT) or another framework (if not), to ensure data quality
-- [ ] Deploy your pipeline using Databricks Asset Bundles
+- [ ] Use Lakeflow Spark Declarative Pipelines (SDP) to build your pipelines
+- [ ] Use expectations (if using SDP) or another framework (if not), to ensure data quality
+- [ ] Deploy your pipeline using Declarative Automation Bundles
 
 #### Level 4 / over 9000
 


### PR DESCRIPTION
Updates the README to current Databricks branding.

- Delta Live Tables (DLT) → Lakeflow / Declarative Pipelines
- Databricks Asset Bundles → Declarative Automation Bundles (+ revo-dabs link)
- Community Edition → Free Edition
- Use https for the Databricks signup link
- Unify "postal code" → "postcode" terminology